### PR TITLE
Add jupyterhub-sftp

### DIFF
--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -8,12 +8,15 @@ charts:
       - ../setup.py
       - ../jupyterhub_ssh
     images:
-      jupyterhub:
+      sftp:
+        contextPath: ../jupyterhub-sftp
+        valuesPath: sftp.image
+      ssh:
         # Context to send to docker build for use by the Dockerfile
         contextPath: ..
         # Dockerfile path relative to chartpress.yaml
         dockerfilePath: images/jupyterhub-ssh/Dockerfile
-        valuesPath: image
+        valuesPath: ssh.image
         # additional paths relevant to the image
         # in addition to image directory itself
         # paths are relative to build.py

--- a/helm-chart/jupyterhub-ssh/Chart.yaml
+++ b/helm-chart/jupyterhub-ssh/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '0.1'
 description: SSH Interface to JupyterHub
 name: jupyterhub-ssh
-version: 0.0.1-n023.h9c46a73
+version: 0.0.1-n026.hf136ec7

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -1,14 +1,15 @@
+{{ if .Values.sftp.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jupyterhub-ssh
+  name: jupyterhub-sftp
   labels:
     app: {{ template "..name" . }}
     chart: {{ template "..chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.sftp.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "..name" . }}
@@ -18,7 +19,8 @@ spec:
       labels:
         app: {{ template "..name" . }}
         release: {{ .Release.Name }}
-        component: ssh-server
+        component: sftp-server
+        hub.jupyter.org/network-access-hub: "true"
       annotations:
         checksum/config-map: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -32,10 +34,15 @@ spec:
         - name: config
           configMap:
             name: jupyterhub-ssh
+        - name: home
+          persistentVolumeClaim:
+            claimName: {{ .Values.sftp.pvc.name }}
       containers:
         - name: server
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.sftp.image.repository }}:{{ .Values.sftp.image.tag }}"
+          imagePullPolicy: {{ .Values.sftp.image.pullPolicy }}
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: secrets
               mountPath: /etc/jupyterhub-ssh/secrets
@@ -43,27 +50,30 @@ spec:
             - name: config
               mountPath: /etc/jupyterhub-ssh/config
               readOnly: true
+            - name: home
+              mountPath: /mnt/home
           ports:
-            - name: ssh
-              containerPort: 8022
+            - name: sftp
+              containerPort: 22
               protocol: TCP
           livenessProbe:
             tcpSocket:
-              port: ssh
+              port: sftp
           readinessProbe:
             tcpSocket:
-              port: ssh
+              port: sftp
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+{{ toYaml .Values.sftp.resources | indent 12 }}
+    {{- with .Values.sftp.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.sftp.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with .Values.sftp.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/netpol.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/netpol.yaml
@@ -1,7 +1,8 @@
+{{ if .Values.sftp.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: jupyterhub-ssh
+  name: jupyterhub-sftp
   labels:
     app: {{ template "..name" . }}
     release: {{ .Release.Name }}
@@ -10,7 +11,7 @@ spec:
     matchLabels:
       app: {{ template "..name" . }}
       release: {{ .Release.Name }}
-      component: ssh-server
+      component: sftp-server
   policyTypes:
   - Ingress
   - Egress
@@ -28,7 +29,8 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          hub.jupyter.org/network-access-ssh-server: "true"
+          hub.jupyter.org/network-access-sftp-server: "true"
     ports:
-      - port: ssh
+      - port: sftp
         protocol: TCP
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
@@ -1,22 +1,24 @@
+{{ if .Values.sftp.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: jupyterhub-ssh
+  name: jupyterhub-sftp
   labels:
     app: {{ template "..name" . }}
     chart: {{ template "..chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.sftp.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: 8022
+    - port: {{ .Values.sftp.service.port }}
+      targetPort: 22
       protocol: TCP
-      name: ssh
-      {{ if eq .Values.service.type "NodePort" }}
-      nodePort: {{ .Values.service.nodePort }}
+      name: sftp
+      {{ if eq .Values.sftp.service.type "NodePort" }}
+      nodePort: {{ .Values.sftp.service.nodePort }}
       {{ end }}
   selector:
     app: {{ template "..name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -1,0 +1,72 @@
+{{ if .Values.ssh.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jupyterhub-ssh
+  labels:
+    app: {{ template "..name" . }}
+    chart: {{ template "..chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.ssh.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "..name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "..name" . }}
+        release: {{ .Release.Name }}
+        component: ssh-server
+        hub.jupyter.org/network-access-hub: "true"
+      annotations:
+        checksum/config-map: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      # We don't need any interaction with k8s API
+      automountServiceAccountToken: false 
+      volumes:
+        - name: secrets
+          secret:
+            secretName: jupyterhub-ssh
+        - name: config
+          configMap:
+            name: jupyterhub-ssh
+      containers:
+        - name: server
+          image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag }}"
+          imagePullPolicy: {{ .Values.ssh.image.pullPolicy }}
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/jupyterhub-ssh/secrets
+              readOnly: true
+            - name: config
+              mountPath: /etc/jupyterhub-ssh/config
+              readOnly: true
+          ports:
+            - name: ssh
+              containerPort: 8022
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: ssh
+          readinessProbe:
+            tcpSocket:
+              port: ssh
+          resources:
+{{ toYaml .Values.ssh.resources | indent 12 }}
+    {{- with .Values.ssh.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.ssh.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.ssh.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/netpol.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/netpol.yaml
@@ -1,0 +1,36 @@
+{{ if .Values.ssh.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: jupyterhub-ssh
+  labels:
+    app: {{ template "..name" . }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "..name" . }}
+      release: {{ .Release.Name }}
+      component: ssh-server
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # FIXME: This is way too permissive
+  - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          hub.jupyter.org/network-access-ssh-server: "true"
+    ports:
+      - port: ssh
+        protocol: TCP
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.ssh.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: jupyterhub-ssh
+  labels:
+    app: {{ template "..name" . }}
+    chart: {{ template "..chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.ssh.service.type }}
+  ports:
+    - port: {{ .Values.ssh.service.port }}
+      targetPort: 8022
+      protocol: TCP
+      name: ssh
+      {{ if eq .Values.ssh.service.type "NodePort" }}
+      nodePort: {{ .Values.ssh.service.nodePort }}
+      {{ end }}
+  selector:
+    app: {{ template "..name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -1,22 +1,56 @@
 # Required to run
 hostKey:
 
-replicaCount: 1
+ssh:
+  enabled: true
 
-image:
-  repository: yuvipanda/jupyterhub-ssh-jupyterhub
-  tag: '0.0.1-n023.h9c46a73'
-  pullPolicy: Always
+  replicaCount: 1
 
-  name: yuvipanda/jupyterhub-ssh-jupyterhub
-service:
-  type: ClusterIP
-  port: 22
+  image:
+    repository: yuvipanda/jupyterhub-ssh-ssh
+    tag: '0.0.1-n026.hf136ec7'
+    pullPolicy: Always
 
-resources: {}
+  service:
+    type: ClusterIP
+    port: 22
 
-nodeSelector: {}
+  resources: {}
 
-tolerations: []
+  labels:
+    hub.jupyter.org/network-access-proxy-http: "true"
 
-affinity: {}
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+
+
+sftp:
+  enabled: true
+  replicaCount: 1
+
+
+  pvc:
+    name:
+
+  image:
+    repository: yuvipanda/jupyterhub-ssh-sftp
+    tag: '0.0.1-n026.hf136ec7'
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    port: 22
+
+  resources: {}
+
+  labels:
+    hub.jupyter.org/network-access-proxy-http: "true"
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}

--- a/jupyterhub-sftp/Dockerfile
+++ b/jupyterhub-sftp/Dockerfile
@@ -1,0 +1,33 @@
+FROM buildpack-deps:focal
+
+RUN apt update --yes > /dev/null && \
+    apt install --yes openssh-server python3 python3-requests python3-ruamel.yaml > /dev/null
+
+ENV NB_UID=1000
+ENV NB_USER jovyan
+
+RUN adduser \
+    --disabled-password \
+    --shell "/sbin/nologin" \
+    --gecos "Default Jupyter user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+
+# Setup NSS so all users are mapped to jovyan
+COPY setup-nss.bash /tmp/setup-nss.bash
+RUN /tmp/setup-nss.bash && rm /tmp/setup-nss.bash
+COPY libnss-ato.conf /etc/libnss-ato.conf
+COPY nsswitch.conf /etc/nsswitch.conf
+
+COPY pam-common-auth /etc/pam.d/common-auth
+COPY jupyterhub-token-verify.py /usr/sbin/jupyterhub-token-verify.py
+
+# Setup SSHD
+# Privilege separation dir (not sure what that is!) needed by sshd
+RUN mkdir /run/sshd
+COPY sshd_config /etc/ssh/sshd_config
+
+RUN mkdir -p /export/home
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-De"]

--- a/jupyterhub-sftp/LICENSE
+++ b/jupyterhub-sftp/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2020, Yuvi Panda
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/jupyterhub-sftp/README.md
+++ b/jupyterhub-sftp/README.md
@@ -1,0 +1,2 @@
+# jupyterhub-sftp
+SFTP server for use with JupyterHub

--- a/jupyterhub-sftp/jupyterhub-token-verify.py
+++ b/jupyterhub-sftp/jupyterhub-token-verify.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import sys
+import os
+import subprocess
+import requests
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')
+
+def valid_user(hub_url, username, token):
+    url = f'{hub_url}/hub/api/user'
+    headers = {
+        'Authorization': f'token {token}'
+    }
+    resp = requests.get(url, headers=headers)
+    return resp.status_code == 200
+
+SRC_DIR = '/mnt/home'
+DEST_DIR = '/export/home'
+
+def bind_mount_user(username):
+    # username is user controlled data, so should be treated more cautiously
+    # It's been authenticated as valid by sshd, but that doesn't mean anything
+    # FIXME: Am pretty sure this is BAD
+    # FIXME: escape username?
+    src_path = os.path.abspath(os.path.join(SRC_DIR, username))
+    dest_chroot_path = os.path.abspath(os.path.join(DEST_DIR, username))
+    dest_bind_path = os.path.join(dest_chroot_path, username)
+
+    if not os.path.exists(dest_chroot_path):
+        os.makedirs(dest_chroot_path, exist_ok=True)
+        os.makedirs(dest_bind_path, exist_ok=True)
+        subprocess.check_call([
+            'mount', '-o', 'bind',
+            src_path, dest_bind_path
+        ])
+
+username = os.environ['PAM_USER']
+password = sys.stdin.read().rstrip('\x00')
+
+with open('/etc/jupyterhub-ssh/config/values.yaml') as f:
+    config = yaml.load(f)
+
+if valid_user(config['hubUrl'], username, password):
+    bind_mount_user(username)
+    sys.exit(0)
+
+sys.exit(1)

--- a/jupyterhub-sftp/libnss-ato.conf
+++ b/jupyterhub-sftp/libnss-ato.conf
@@ -1,0 +1,2 @@
+# Copy pasted from /etc/passwd of built image
+jovyan:x:1000:1000:Default Jupyter user,,,:/home/jovyan:/sbin/nologin

--- a/jupyterhub-sftp/nsswitch.conf
+++ b/jupyterhub-sftp/nsswitch.conf
@@ -1,0 +1,16 @@
+# nsswitch that reads from files and ato
+# we only modify passwd & shadow, although I'm not sure what overriding shadow does
+passwd:         files ato systemd
+group:          files systemd
+shadow:         files ato
+gshadow:        files
+
+hosts:          files dns
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis

--- a/jupyterhub-sftp/pam-common-auth
+++ b/jupyterhub-sftp/pam-common-auth
@@ -1,0 +1,15 @@
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Our "Special Script"
+
+auth sufficient pam_exec.so expose_authtok debug log=/tmp/debug.log /usr/sbin/jupyterhub-token-verify.py
+
+# here are the per-package modules (the "Primary" block)
+auth    [success=1 default=ignore]  pam_unix.so nullok_secure
+# here's the fallback if no module succeeds
+auth    requisite           pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required            pam_permit.so

--- a/jupyterhub-sftp/pam-verify
+++ b/jupyterhub-sftp/pam-verify
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+password = sys.stdin.read()
+username = os.environ.get('PAM_USER')
+
+print(password)
+if password == username:
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/jupyterhub-sftp/proftp-sftp.conf
+++ b/jupyterhub-sftp/proftp-sftp.conf
@@ -1,0 +1,20 @@
+<IfModule mod_sftp.c>
+
+        SFTPEngine on
+        Port 22
+        SFTPLog /var/log/proftpd/sftp.log
+
+        # Configure both the RSA and DSA host keys, using the same host key
+        # files that OpenSSH uses.
+        SFTPHostKey /etc/ssh/ssh_host_rsa_key
+
+        RequireValidShell off
+
+        SFTPAuthMethods keyboard-interactive
+
+        SFTPAuthorizedUserKeys file:/etc/proftpd/authorized_keys/%u
+
+        # Enable compression
+        SFTPCompression delayed
+
+</IfModule>

--- a/jupyterhub-sftp/setup-nss.bash
+++ b/jupyterhub-sftp/setup-nss.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# FIXME: Pin this
+git clone --depth 1 https://github.com/donapieppo/libnss-ato
+pushd libnss-ato
+
+make
+make install
+
+popd
+rm -rf libnss-ato

--- a/jupyterhub-sftp/sshd_config
+++ b/jupyterhub-sftp/sshd_config
@@ -1,0 +1,81 @@
+#	$OpenBSD: sshd_config,v 1.103 2018/04/09 20:41:22 tj Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Include /etc/ssh/sshd_config.d/*.conf
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+# Only allow password auth, BECAUSE WE ARE EVIL HAHA
+PubkeyAuthentication no
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication yes
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+# We really only want sftp
+AllowAgentForwarding No
+AllowTcpForwarding no
+GatewayPorts no
+X11Forwarding no
+PermitTTY no
+PrintMotd no
+PrintLastLog no
+TCPKeepAlive yes
+PermitUserEnvironment no
+PermitTunnel no
+
+# no default banner path
+#Banner none
+
+# Use the built-in internal-sftp setup, rather than shelling out to sftp-server
+Subsystem	sftp	internal-sftp
+
+# Only allow sftp
+ChrootDirectory /export/home/%u
+ForceCommand internal-sftp -d %u


### PR DESCRIPTION
Talking to users, SFTP / SCP was cited as the biggest usecase
they see for ssh. We could theoretically implement it with
asyncssh, but we don't have a clear way to support all the
operations SFTP wants with just the Notebook Contents API -
there's no read at / write at / open functionality. Besides,
the folks who want to use SFTP want to use it for high
performance file transfer, and that would be a bit of work.

Instead, for now, we add an SFTP setup with OpenSSH directly.
SFTP doesn't require or allow arbitrary code execution, so
we don't need to force the environment to match what the
JupyterHub provides. We just need to match the *home*
directories.

In this case, we only support NFS based home directories.
This isn't as agnostic as jupyterhub-ssh, but it works
in the following use cases:

1. All user files are owned by the same UID (currently
   hardcoded to 1000).
2. The NFS share containing them can be mounted in the
   pod serving SFTP
3. JupyterHub token authentication will be used to
   authenticate users
4. You can map from JupyterHub user name to NFS path
   easily and consistently

In these cases, it works fairly well!

OpenSSH doesn't really support pluggable auth, mostly
expecting system users to exist. This is in two
parts:

1. The username exists and is mapped to a given id,
   aquired via standard Linux mechanisms (`getent`)
2. The password is valid and authenticated via
   standard Linux mechanisms (PAM)

We do (1) with [libnss-ato](https://github.com/donapieppo/libnss-ato),
and (2) with [pam_exec](https://linux.die.net/man/8/pam_exec). These
help us pretend that each JupyterHub user exists (with uid 1000),
and their password is a valid JupyterHub token! This probably
has uses beyond this, an exercise for another day.

We will re-use the key from jupyterhub-ssh, but operate on a different
port. Traefik can still route us TCP traffic, so all good!

FWIW, I also spent some time on proftpd, which has an SFTP module.
I was side-tracked by the `!` SFTP command (pops a local shell,
I thought it popped a remote shell!), but stuck to OpenSSH
regardless - it's more battle tested and easier to configure.


----

#