### PR TITLE
Many different Helm chart updates

### DIFF
--- a/helm-chart/images/jupyterhub-ssh/Dockerfile
+++ b/helm-chart/images/jupyterhub-ssh/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.8-slim
 
-WORKDIR /srv/jupyterhub-ssh
+# Ensure Python logs are made available for k8s directly
+ENV PYTHONUNBUFFERED=1
 
-ENV NB_UID=1000
-ENV NB_USER jovyan
-
+# Prepare a user
+ENV NB_UID=1000 \
+    NB_USER=jovyan
 RUN adduser \
     --disabled-password \
     --shell "/sbin/nologin" \
@@ -12,11 +13,16 @@ RUN adduser \
     --uid ${NB_UID} \
     ${NB_USER}
 
+# FIXME: This isn't great, consider for example locally building and pushing an
+#        image, then one could very well end up embedding sensitive content into
+#        something one has made public.
+WORKDIR /srv/jupyterhub-ssh
 COPY . .
 COPY helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py .
 
+# Install jupyterhub_ssh the Python package
 RUN pip3 install --no-cache-dir .
 
+# Configure to run jupyterhub_ssh
 USER $NB_UID
-
 ENTRYPOINT [ "python3", "-m", "jupyterhub_ssh" ]

--- a/helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py
+++ b/helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py
@@ -1,12 +1,9 @@
 from ruamel.yaml import YAML
 
 yaml = YAML()
-
-c.JupyterHubSSH.host_key_path = '/etc/jupyterhub-ssh/secrets/jupyterhub-ssh.host-key'
-c.JupyterHubSSH.debug = True
-
-with open('/etc/jupyterhub-ssh/config/values.yaml') as f:
+with open("/etc/jupyterhub-ssh/config/values.yaml") as f:
     config = yaml.load(f)
 
-
-c.JupyterHubSSH.hub_url = config['hubUrl']
+c.JupyterHubSSH.host_key_path = "/etc/jupyterhub-ssh/config/hostKey"
+c.JupyterHubSSH.hub_url = config["hubUrl"]
+c.JupyterHubSSH.debug = True

--- a/helm-chart/jupyterhub-ssh/Chart.yaml
+++ b/helm-chart/jupyterhub-ssh/Chart.yaml
@@ -1,5 +1,20 @@
-apiVersion: v1
-appVersion: '0.1'
-description: SSH Interface to JupyterHub
+# Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
+apiVersion: v2
 name: jupyterhub-ssh
-version: 0.0.1-n026.hf136ec7
+version: 0.0.1-set.by.chartpress
+appVersion: 0.1.0
+description: SSH interface to JupyterHub
+keywords:
+  - jupyterhub
+  - ssh
+  - stfp
+home: https://github.com/yuvipanda/jupyterhub-ssh
+sources:
+  - https://github.com/yuvipanda/jupyterhub-ssh
+icon: https://jupyter.org/assets/hublogo.svg
+maintainers:
+  # Since it is a requirement of Artifact Hub to have specific maintainers
+  # listed, we have added some below, but in practice the entire JupyterHub team
+  # contributes to the maintenance of this Helm chart.
+  - name: Erik Sundell
+    email: erik@sundellopensource.se

--- a/helm-chart/jupyterhub-ssh/templates/NOTES.txt
+++ b/helm-chart/jupyterhub-ssh/templates/NOTES.txt
@@ -1,1 +1,0 @@
-{{ $dummy := .Values.hubUrl | required "hubUrl must be set to a valid JupyterHub URL" }}

--- a/helm-chart/jupyterhub-ssh/templates/NOTES.txt
+++ b/helm-chart/jupyterhub-ssh/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{ $dummy := .Values.hubUrl | required "hubUrl must be set to a valid JupyterHub URL" }}

--- a/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
+++ b/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
@@ -1,20 +1,21 @@
 {{/*
-Expand the name of the chart.
+name is used to set the app.kubernetes.io/name label and influences the fullname
+function if fullnameOverride isn't specified.
 */}}
 {{- define "jupyterhub-ssh.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+fullname is used to name k8s resources either directly based on fullnameOverride,
+or by combining the helm release name with the chart name. If the release name
+contains the chart name, the chart name won't be repeated.
 */}}
 {{- define "jupyterhub-ssh.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := .Values.nameOverride | default .Chart.Name }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -32,14 +33,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Create chart name and version as used by the chart label.
+chart is used to set the helm.sh/chart label.
 */}}
 {{- define "jupyterhub-ssh.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-Common labels
+labels are selectorLabels and other common labels k8s resources get
 */}}
 {{- define "jupyterhub-ssh.labels" -}}
 helm.sh/chart: {{ include "jupyterhub-ssh.chart" . }}
@@ -61,7 +62,12 @@ app.kubernetes.io/component: ssh
 {{- end }}
 
 {{/*
-Selector labels
+selectorLabels are used to taget specific resources, such as how Services and
+Deployment resources target Pods. Changes to this will be breaking changes.
+Deployment's matchLabels field are for example immutable and will require the
+resource to be recreated. Handling breaking changes was quite easy to do with
+`helm2 upgrade --force` but require manual intervention in `helm3 upgrade` by
+manually deleting the Deployment resources first.
 */}}
 {{- define "jupyterhub-ssh.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "jupyterhub-ssh.name" . }}

--- a/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
+++ b/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
@@ -24,11 +24,11 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{- define "jupyterhub-ssh.sftp.fullname" -}}
-{{ include "jupyterhub-ssh.fullname" . }}-sftp-server
+{{ include "jupyterhub-ssh.fullname" . }}-sftp
 {{- end }}
 
 {{- define "jupyterhub-ssh.ssh.fullname" -}}
-{{ include "jupyterhub-ssh.fullname" . }}-ssh-server
+{{ include "jupyterhub-ssh.fullname" . }}-ssh
 {{- end }}
 
 {{/*
@@ -52,12 +52,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{- define "jupyterhub-ssh.sftp.labels" -}}
 {{ include "jupyterhub-ssh.labels" . }}
-app.kubernetes.io/component: sftp-server
+app.kubernetes.io/component: sftp
 {{- end }}
 
 {{- define "jupyterhub-ssh.ssh.labels" -}}
 {{ include "jupyterhub-ssh.labels" . }}
-app.kubernetes.io/component: ssh-server
+app.kubernetes.io/component: ssh
 {{- end }}
 
 {{/*

--- a/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
+++ b/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
@@ -1,32 +1,79 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "..name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "jupyterhub-ssh.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "..fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "jupyterhub-ssh.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub-ssh.sftp.fullname" -}}
+{{ include "jupyterhub-ssh.fullname" . }}-sftp-server
+{{- end }}
+
+{{- define "jupyterhub-ssh.ssh.fullname" -}}
+{{ include "jupyterhub-ssh.fullname" . }}-ssh-server
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "..chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "jupyterhub-ssh.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "jupyterhub-ssh.labels" -}}
+helm.sh/chart: {{ include "jupyterhub-ssh.chart" . }}
+{{ include "jupyterhub-ssh.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "jupyterhub-ssh.sftp.labels" -}}
+{{ include "jupyterhub-ssh.labels" . }}
+app.kubernetes.io/component: sftp-server
+{{- end }}
+
+{{- define "jupyterhub-ssh.ssh.labels" -}}
+{{ include "jupyterhub-ssh.labels" . }}
+app.kubernetes.io/component: ssh-server
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jupyterhub-ssh.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jupyterhub-ssh.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "jupyterhub-ssh.sftp.selectorLabels" -}}
+{{ include "jupyterhub-ssh.selectorLabels" . }}
+app.kubernetes.io/component: sftp-server
+{{- end }}
+
+{{- define "jupyterhub-ssh.ssh.selectorLabels" -}}
+{{ include "jupyterhub-ssh.selectorLabels" . }}
+app.kubernetes.io/component: ssh-server
+{{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
+++ b/helm-chart/jupyterhub-ssh/templates/_helpers.tpl
@@ -70,10 +70,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "jupyterhub-ssh.sftp.selectorLabels" -}}
 {{ include "jupyterhub-ssh.selectorLabels" . }}
-app.kubernetes.io/component: sftp-server
+app.kubernetes.io/component: sftp
 {{- end }}
 
 {{- define "jupyterhub-ssh.ssh.selectorLabels" -}}
 {{ include "jupyterhub-ssh.selectorLabels" . }}
-app.kubernetes.io/component: ssh-server
+app.kubernetes.io/component: ssh
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/configmap.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "jupyterhub-ssh.labels" . | nindent 4 }}
 data:
   values.yaml: |
-    {{ .Values | toYaml | nindent 4 }}
+    {{- .Values | toYaml | nindent 4 }}

--- a/helm-chart/jupyterhub-ssh/templates/configmap.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/configmap.yaml
@@ -1,12 +1,9 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: jupyterhub-ssh
+  name: {{ include "jupyterhub-ssh.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    chart: {{ template "..chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "jupyterhub-ssh.labels" . | nindent 4 }}
 data:
   values.yaml: |
     {{ .Values | toYaml | nindent 4 }}

--- a/helm-chart/jupyterhub-ssh/templates/configmap.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/configmap.yaml
@@ -1,9 +1,0 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: {{ include "jupyterhub-ssh.fullname" . }}
-  labels:
-    {{- include "jupyterhub-ssh.labels" . | nindent 4 }}
-data:
-  values.yaml: |
-    {{- .Values | toYaml | nindent 4 }}

--- a/helm-chart/jupyterhub-ssh/templates/secret.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/secret.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     {{- include "jupyterhub-ssh.labels" . | nindent 4 }}
 type: Opaque
-data:
-  jupyterhub-ssh.host-key: {{ (required "hostKey must be set to a valid SSH Private key" .Values.hostKey) | b64enc | quote }}
+stringData:
+  values.yaml: |
+    {{- .Values | toYaml | nindent 4 }}
+  hostKey: {{ .Values.hostKey | required "hostKey must be set to a valid SSH Private key" | quote }}

--- a/helm-chart/jupyterhub-ssh/templates/secret.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/secret.yaml
@@ -9,3 +9,4 @@ stringData:
   values.yaml: |
     {{- .Values | toYaml | nindent 4 }}
   hostKey: {{ .Values.hostKey | required "hostKey must be set to a valid SSH Private key" | quote }}
+  hostUrl: {{ .Values.hubUrl | required "hubUrl must be set to a valid JupyterHub URL" | quote }}

--- a/helm-chart/jupyterhub-ssh/templates/secret.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/secret.yaml
@@ -1,12 +1,9 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: jupyterhub-ssh
+  name: {{ include "jupyterhub-ssh.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    chart: {{ template "..chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "jupyterhub-ssh.labels" . | nindent 4 }}
 type: Opaque
 data:
   jupyterhub-ssh.host-key: {{ (required "hostKey must be set to a valid SSH Private key" .Values.hostKey) | b64enc | quote }}

--- a/helm-chart/jupyterhub-ssh/templates/secret.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/secret.yaml
@@ -9,4 +9,4 @@ stringData:
   values.yaml: |
     {{- .Values | toYaml | nindent 4 }}
   hostKey: {{ .Values.hostKey | required "hostKey must be set to a valid SSH Private key" | quote }}
-  hostUrl: {{ .Values.hubUrl | required "hubUrl must be set to a valid JupyterHub URL" | quote }}
+  hubUrl: {{ .Values.hubUrl | required "hubUrl must be set to a valid JupyterHub URL" | quote }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -38,6 +38,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "jupyterhub-ssh.fullname" . }}
                   key: hubUrl
+            - name: HOST_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jupyterhub-ssh.fullname" . }}
+                  key: hostKey
           imagePullPolicy: {{ .Values.sftp.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "jupyterhub-ssh.sftp.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ omit .Values "ssh" | toYaml | sha256sum }}
     spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -2,24 +2,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jupyterhub-sftp
+  name: {{ include "jupyterhub-ssh.sftp.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    chart: {{ template "..chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "jupyterhub-ssh.sftp.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.sftp.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "..name" . }}
-      release: {{ .Release.Name }}
+      {{- include "jupyterhub-ssh.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "..name" . }}
-        release: {{ .Release.Name }}
-        component: sftp-server
+        {{- include "jupyterhub-ssh.sftp.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
       annotations:
         checksum/config-map: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -30,10 +24,10 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: jupyterhub-ssh
+            secretName: {{ include "jupyterhub-ssh.fullname" . }}
         - name: config
           configMap:
-            name: jupyterhub-ssh
+            name: {{ include "jupyterhub-ssh.fullname" . }}
         - name: home
           persistentVolumeClaim:
             claimName: {{ .Values.sftp.pvc.name }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -16,18 +16,14 @@ spec:
         {{- include "jupyterhub-ssh.sftp.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
       annotations:
-        checksum/config-map: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 
       volumes:
-        - name: secrets
+        - name: config
           secret:
             secretName: {{ include "jupyterhub-ssh.fullname" . }}
-        - name: config
-          configMap:
-            name: {{ include "jupyterhub-ssh.fullname" . }}
         - name: home
           persistentVolumeClaim:
             claimName: {{ .Values.sftp.pvc.name }}
@@ -38,9 +34,6 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
-            - name: secrets
-              mountPath: /etc/jupyterhub-ssh/secrets
-              readOnly: true
             - name: config
               mountPath: /etc/jupyterhub-ssh/config
               readOnly: true

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -26,22 +26,22 @@ spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 
       volumes:
-        - name: config
-          secret:
-            secretName: {{ include "jupyterhub-ssh.fullname" . }}
         - name: home
           persistentVolumeClaim:
             claimName: {{ .Values.sftp.pvc.name }}
       containers:
         - name: server
           image: "{{ .Values.sftp.image.repository }}:{{ .Values.sftp.image.tag | default .Chart.AppVersion }}"
+          env:
+            - name: HUB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jupyterhub-ssh.fullname" . }}
+                  key: hubUrl
           imagePullPolicy: {{ .Values.sftp.image.pullPolicy }}
           securityContext:
             privileged: true
           volumeMounts:
-            - name: config
-              mountPath: /etc/jupyterhub-ssh/config
-              readOnly: true
             - name: home
               mountPath: /mnt/home
           ports:

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.sftp.enabled }}
+{{- if .Values.sftp.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,17 +51,17 @@ spec:
               containerPort: 2222
               protocol: TCP
           resources:
-{{ toYaml .Values.sftp.resources | indent 12 }}
-    {{- with .Values.sftp.nodeSelector }}
+            {{- .Values.sftp.resources | toYaml | nindent 12 }}
+      {{- with .Values.sftp.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.sftp.affinity }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sftp.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.sftp.tolerations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sftp.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             items:
               - key: hostKey
                 path: hostKey
+                mode: 0400
               - key: hubUrl
                 path: hubUrl
       containers:

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -14,9 +14,14 @@ spec:
     metadata:
       labels:
         {{- include "jupyterhub-ssh.sftp.labels" . | nindent 8 }}
-        hub.jupyter.org/network-access-hub: "true"
+        {{- with .Values.sftp.podLabels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ omit .Values "ssh" | toYaml | sha256sum }}
+        {{- with .Values.sftp.podAnnotations }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -29,26 +29,30 @@ spec:
         - name: home
           persistentVolumeClaim:
             claimName: {{ .Values.sftp.pvc.name }}
+        # Selects only parts of the k8s Secret as a Volume. Note that we can
+        # also specify a mode for individual files at this point, for example to
+        # make the hostKey read only in the file system.
+        #
+        # ref: https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1-core
+        - name: config
+          secret:
+            secretName: {{ include "jupyterhub-ssh.fullname" . }}
+            items:
+              - key: hostKey
+                path: hostKey
+              - key: hubUrl
+                path: hubUrl
       containers:
         - name: server
           image: "{{ .Values.sftp.image.repository }}:{{ .Values.sftp.image.tag | default .Chart.AppVersion }}"
-          env:
-            - name: HUB_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "jupyterhub-ssh.fullname" . }}
-                  key: hubUrl
-            - name: HOST_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "jupyterhub-ssh.fullname" . }}
-                  key: hostKey
           imagePullPolicy: {{ .Values.sftp.image.pullPolicy }}
           securityContext:
             privileged: true
           volumeMounts:
             - name: home
               mountPath: /mnt/home
+            - name: config
+              mountPath: /etc/jupyterhub-sftp/config
           ports:
             - name: sftp
               containerPort: 2222

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             claimName: {{ .Values.sftp.pvc.name }}
       containers:
         - name: server
-          image: "{{ .Values.sftp.image.repository }}:{{ .Values.sftp.image.tag }}"
+          image: "{{ .Values.sftp.image.repository }}:{{ .Values.sftp.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.sftp.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -50,6 +50,10 @@ spec:
               protocol: TCP
           resources:
             {{- .Values.sftp.resources | toYaml | nindent 12 }}
+      {{- with .Values.sftp.imagePullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.sftp.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/deployment.yaml
@@ -53,6 +53,7 @@ spec:
               mountPath: /mnt/home
             - name: config
               mountPath: /etc/jupyterhub-sftp/config
+              readOnly: true
           ports:
             - name: sftp
               containerPort: 2222

--- a/helm-chart/jupyterhub-ssh/templates/sftp/netpol.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/netpol.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.sftp.enabled }}
+{{- if .Values.sftp.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,9 +20,10 @@ spec:
       port: 53
   # FIXME: This is way too permissive
   - to:
-      - ipBlock:
-          cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: 0.0.0.0/0
   ingress:
+  # Allow pods in the same namespace with this label to have network access
   - from:
     - podSelector:
         matchLabels:

--- a/helm-chart/jupyterhub-ssh/templates/sftp/netpol.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/netpol.yaml
@@ -2,16 +2,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: jupyterhub-sftp
+  name: {{ include "jupyterhub-ssh.sftp.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    release: {{ .Release.Name }}
+    {{- include "jupyterhub-ssh.sftp.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "..name" . }}
-      release: {{ .Release.Name }}
-      component: sftp-server
+      {{- include "jupyterhub-ssh.sftp.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Ingress
   - Egress

--- a/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
@@ -2,12 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: jupyterhub-sftp
+  name: {{ include "jupyterhub-ssh.sftp.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    chart: {{ template "..chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "jupyterhub-ssh.sftp.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.sftp.service.type }}
   ports:
@@ -19,6 +16,5 @@ spec:
       nodePort: {{ .Values.sftp.service.nodePort }}
       {{ end }}
   selector:
-    app: {{ template "..name" . }}
-    release: {{ .Release.Name }}
+    {{- include "jupyterhub-ssh.sftp.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.sftp.enabled }}
+{{- if .Values.sftp.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,9 +12,9 @@ spec:
       targetPort: 2222
       protocol: TCP
       name: sftp
-      {{ if eq .Values.sftp.service.type "NodePort" }}
+      {{- if eq .Values.sftp.service.type "NodePort" }}
       nodePort: {{ .Values.sftp.service.nodePort }}
-      {{ end }}
+      {{- end }}
   selector:
     {{- include "jupyterhub-ssh.sftp.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "jupyterhub-ssh.sftp.fullname" . }}
   labels:
     {{- include "jupyterhub-ssh.sftp.labels" . | nindent 4 }}
+    {{- with .Values.sftp.serviceLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  {{- with .Values.sftp.serviceAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.sftp.service.type }}
   ports:

--- a/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/sftp/service.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   type: {{ .Values.sftp.service.type }}
   ports:
-    - port: {{ .Values.sftp.service.port }}
-      targetPort: 2222
+    - name: sftp
+      port: {{ .Values.sftp.service.port }}
+      targetPort: sftp
       protocol: TCP
-      name: sftp
       {{- if eq .Values.sftp.service.type "NodePort" }}
       nodePort: {{ .Values.sftp.service.nodePort }}
       {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -2,24 +2,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jupyterhub-ssh
+  name: {{ include "jupyterhub-ssh.ssh.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    chart: {{ template "..chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "jupyterhub-ssh.ssh.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.ssh.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "..name" . }}
-      release: {{ .Release.Name }}
+      {{- include "jupyterhub-ssh.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "..name" . }}
-        release: {{ .Release.Name }}
-        component: ssh-server
+        {{- include "jupyterhub-ssh.ssh.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
       annotations:
         checksum/config-map: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -30,10 +24,10 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: jupyterhub-ssh
+            secretName: {{ include "jupyterhub-ssh.fullname" . }}
         - name: config
           configMap:
-            name: jupyterhub-ssh
+            name: {{ include "jupyterhub-ssh.fullname" . }}
       containers:
         - name: server
           image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag }}"

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             secretName: {{ include "jupyterhub-ssh.fullname" . }}
       containers:
         - name: server
-          image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag }}"
+          image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.ssh.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -16,18 +16,14 @@ spec:
         {{- include "jupyterhub-ssh.ssh.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
       annotations:
-        checksum/config-map: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 
       volumes:
-        - name: secrets
+        - name: config
           secret:
             secretName: {{ include "jupyterhub-ssh.fullname" . }}
-        - name: config
-          configMap:
-            name: {{ include "jupyterhub-ssh.fullname" . }}
       containers:
         - name: server
           image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag }}"
@@ -36,9 +32,6 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
           volumeMounts:
-            - name: secrets
-              mountPath: /etc/jupyterhub-ssh/secrets
-              readOnly: true
             - name: config
               mountPath: /etc/jupyterhub-ssh/config
               readOnly: true

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -46,6 +46,10 @@ spec:
               protocol: TCP
           resources:
             {{- .Values.ssh.resources | toYaml | nindent 12 }}
+      {{- with .Values.ssh.imagePullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.ssh.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -14,9 +14,14 @@ spec:
     metadata:
       labels:
         {{- include "jupyterhub-ssh.ssh.labels" . | nindent 8 }}
-        hub.jupyter.org/network-access-hub: "true"
+        {{- with .Values.ssh.podLabels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ omit .Values "sftp" | toYaml | sha256sum }}
+        {{- with .Values.ssh.podAnnotations }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "jupyterhub-ssh.ssh.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ omit .Values "sftp" | toYaml | sha256sum }}
     spec:
       # We don't need any interaction with k8s API
       automountServiceAccountToken: false 

--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ssh.enabled }}
+{{- if .Values.ssh.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -47,17 +47,17 @@ spec:
               containerPort: 8022
               protocol: TCP
           resources:
-{{ toYaml .Values.ssh.resources | indent 12 }}
-    {{- with .Values.ssh.nodeSelector }}
+            {{- .Values.ssh.resources | toYaml | nindent 12 }}
+      {{- with .Values.ssh.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.ssh.affinity }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ssh.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.ssh.tolerations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ssh.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/netpol.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/netpol.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ssh.enabled }}
+{{- if .Values.ssh.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,9 +20,10 @@ spec:
       port: 53
   # FIXME: This is way too permissive
   - to:
-      - ipBlock:
-          cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: 0.0.0.0/0
   ingress:
+  # Allow pods in the same namespace with this label to have network access
   - from:
     - podSelector:
         matchLabels:

--- a/helm-chart/jupyterhub-ssh/templates/ssh/netpol.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/netpol.yaml
@@ -2,16 +2,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: jupyterhub-ssh
+  name: {{ include "jupyterhub-ssh.ssh.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    release: {{ .Release.Name }}
+    {{- include "jupyterhub-ssh.ssh.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "..name" . }}
-      release: {{ .Release.Name }}
-      component: ssh-server
+      {{- include "jupyterhub-ssh.ssh.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Ingress
   - Egress

--- a/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   type: {{ .Values.ssh.service.type }}
   ports:
-    - port: {{ .Values.ssh.service.port }}
-      targetPort: 8022
+    - name: ssh
+      port: {{ .Values.ssh.service.port }}
+      targetPort: ssh
       protocol: TCP
-      name: ssh
       {{- if eq .Values.ssh.service.type "NodePort" }}
       nodePort: {{ .Values.ssh.service.nodePort }}
       {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ssh.enabled }}
+{{- if .Values.ssh.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,9 +12,9 @@ spec:
       targetPort: 8022
       protocol: TCP
       name: ssh
-      {{ if eq .Values.ssh.service.type "NodePort" }}
+      {{- if eq .Values.ssh.service.type "NodePort" }}
       nodePort: {{ .Values.ssh.service.nodePort }}
-      {{ end }}
+      {{- end }}
   selector:
     {{- include "jupyterhub-ssh.ssh.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
@@ -2,12 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: jupyterhub-ssh
+  name: {{ include "jupyterhub-ssh.ssh.fullname" . }}
   labels:
-    app: {{ template "..name" . }}
-    chart: {{ template "..chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "jupyterhub-ssh.ssh.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.ssh.service.type }}
   ports:
@@ -19,6 +16,5 @@ spec:
       nodePort: {{ .Values.ssh.service.nodePort }}
       {{ end }}
   selector:
-    app: {{ template "..name" . }}
-    release: {{ .Release.Name }}
+    {{- include "jupyterhub-ssh.ssh.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/service.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "jupyterhub-ssh.ssh.fullname" . }}
   labels:
     {{- include "jupyterhub-ssh.ssh.labels" . | nindent 4 }}
+    {{- with .Values.ssh.serviceLabels }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ssh.serviceAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.ssh.service.type }}
   ports:

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -1,6 +1,9 @@
 # Required to run
-hubUrl:
-hostKey:
+hubUrl: ""
+hostKey: ""
+
+nameOverride: ""
+fullnameOverride: ""
 
 ssh:
   enabled: true
@@ -15,15 +18,16 @@ ssh:
     type: ClusterIP
     port: 22
 
-  resources: {}
-
-  labels:
+  podLabels:
+    hub.jupyter.org/network-access-hub: "true"
     hub.jupyter.org/network-access-proxy-http: "true"
+  podAnnotations: {}
+  serviceLabels: {}
+  serviceAnnotations: {}
 
+  resources: {}
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
 
 
@@ -33,24 +37,25 @@ sftp:
   replicaCount: 1
 
   pvc:
-    name:
+    name: ""
 
   image:
     repository: yuvipanda/jupyterhub-ssh-sftp
-    tag: '0.0.1-n026.hf136ec7'
+    tag: "0.0.1-n026.hf136ec7"
     pullPolicy: Always
 
   service:
     type: ClusterIP
     port: 22
 
-  resources: {}
-
-  labels:
+  podLabels:
+    hub.jupyter.org/network-access-hub: "true"
     hub.jupyter.org/network-access-proxy-http: "true"
+  podAnnotations: {}
+  serviceLabels: {}
+  serviceAnnotations: {}
 
+  resources: {}
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -1,4 +1,5 @@
 # Required to run
+hubUrl:
 hostKey:
 
 ssh:

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -26,6 +26,7 @@ ssh:
   serviceAnnotations: {}
 
   resources: {}
+  imagePullSecrets: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -56,6 +57,7 @@ sftp:
   serviceAnnotations: {}
 
   resources: {}
+  imagePullSecrets: []
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -4,7 +4,6 @@ hostKey:
 
 ssh:
   enabled: true
-
   replicaCount: 1
 
   image:
@@ -33,7 +32,6 @@ sftp:
   enabled: true
   replicaCount: 1
 
-
   pvc:
     name:
 
@@ -41,6 +39,7 @@ sftp:
     repository: yuvipanda/jupyterhub-ssh-sftp
     tag: '0.0.1-n026.hf136ec7'
     pullPolicy: Always
+
   service:
     type: ClusterIP
     port: 22

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -1,9 +1,24 @@
-# Required to run
+# Required configuration
+# hubUrl should be a URL like http://hub:8081 or https://jupyter.example.org.
+# Only HTTP(S) traffic will be sent to this URL.
 hubUrl: ""
+# hostKey is a private SSH key.
+# FIXME: Explain a bit where/how it is used as well.
 hostKey: ""
 
+# nameOverride if set, will override the name of the chart in two contexts.
+# 1. The label: app.kubernetes.io/name: <chart name>
+# 2. The Helm template function: jupyterhub-ssh.fullname, if fullnameOverride
+#    isn't set because then it takes precedence.
 nameOverride: ""
-fullnameOverride: ""
+# fullnameOverride set to a truthy value will make all k8s resources be named
+# <fullnameOverride> with an optional prefix. But if fullnameOverride is set to
+# a falsy value will make all k8s resource names become either <release
+# name>-<chart name> with an optional suffix, or <release name> with an optional
+# suffix. The chart name part is excluded if release name is found to contain
+# the chart name.
+fullnameOverride: "jupyterhub"
+
 
 ssh:
   enabled: true
@@ -30,7 +45,6 @@ ssh:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
 
 
 sftp:

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -37,6 +37,8 @@ sftp:
   enabled: true
   replicaCount: 1
 
+  # Not yet implemented. If we want this though, we should probably make sftp a
+  # statefulset!
   pvc:
     name: ""
 

--- a/jupyterhub-sftp/Dockerfile
+++ b/jupyterhub-sftp/Dockerfile
@@ -35,5 +35,5 @@ COPY sshd_config /etc/ssh/sshd_config
 
 RUN mkdir -p /export/home
 
-EXPOSE 22
+EXPOSE 2222
 CMD ["/usr/sbin/sshd", "-De"]

--- a/jupyterhub-sftp/Dockerfile
+++ b/jupyterhub-sftp/Dockerfile
@@ -24,7 +24,7 @@ COPY pam-common-auth /etc/pam.d/common-auth
 
 RUN python3 -m venv ${VENV_PATH}
 # FIXME: Get this from a fully frozen requirements.txt file plz
-RUN ${VENV_PATH}/bin/pip install --no-cache escapism requests ruamel.yaml
+RUN ${VENV_PATH}/bin/pip install --no-cache escapism requests
 
 COPY jupyterhub-token-verify.py /usr/sbin/jupyterhub-token-verify.py
 

--- a/jupyterhub-sftp/jupyterhub-token-verify.py
+++ b/jupyterhub-sftp/jupyterhub-token-verify.py
@@ -127,7 +127,10 @@ untrusted_username = os.environ['PAM_USER']
 # Password is a null delimited string, passed in via stdin by pam_exec
 password = sys.stdin.read().rstrip('\x00')
 
-if valid_user(os.environ["HUB_URL"], untrusted_username, password):
+with open('/etc/jupyterhub-sftp/config/hubUrl', 'r') as f:
+    hub_url = f.read()
+
+if valid_user(hub_url, untrusted_username, password):
     # FIXME: We're doing a bind mount here based on an untrusted_username
     # THIS IS *SCARY* and we should do more work to ensure we aren't
     # accidentally exposing user data.

--- a/jupyterhub-sftp/jupyterhub-token-verify.py
+++ b/jupyterhub-sftp/jupyterhub-token-verify.py
@@ -53,16 +53,14 @@ controls ${USERNAME}. If we aren't careful, they can use it to have us
 give them read (and possibly write) access to *any* part of the filesystem.
 So we have to be very careful doing this.
 """
-import sys
 import os
-import subprocess
 import requests
-from ruamel.yaml import YAML
-from escapism import escape
 import string
-from pathlib import PosixPath
+import subprocess
+import sys
 
-yaml = YAML(typ='safe')
+from escapism import escape
+from pathlib import PosixPath
 
 def valid_user(hub_url, username, token):
     """
@@ -129,15 +127,7 @@ untrusted_username = os.environ['PAM_USER']
 # Password is a null delimited string, passed in via stdin by pam_exec
 password = sys.stdin.read().rstrip('\x00')
 
-# We read the config file *just* to get the hub URL
-# FIXME: Maybe get rid of the YAML dependency here?
-# FIXME: Make sure the file is owned by root & has proper perms!
-with open('/etc/jupyterhub-ssh/config/values.yaml') as f:
-    config = yaml.load(f)
-
-hub_url = config['hubUrl']
-
-if valid_user(hub_url, untrusted_username, password):
+if valid_user(os.environ["HUB_URL"], untrusted_username, password):
     # FIXME: We're doing a bind mount here based on an untrusted_username
     # THIS IS *SCARY* and we should do more work to ensure we aren't
     # accidentally exposing user data.

--- a/jupyterhub-sftp/sshd_config
+++ b/jupyterhub-sftp/sshd_config
@@ -17,9 +17,8 @@ Port 2222
 #ListenAddress 0.0.0.0
 #ListenAddress ::
 
-#HostKey /etc/ssh/ssh_host_rsa_key
-#HostKey /etc/ssh/ssh_host_ecdsa_key
-#HostKey /etc/ssh/ssh_host_ed25519_key
+# This file is assumed to be mounted to the Docker container
+HostKey /etc/jupyterhub-sftp/config/hostKey
 
 # Ciphers and keying
 #RekeyLimit default none


### PR DESCRIPTION
PR addressing ideas in #17, closing #17.

@yuvipanda I updated issue #17 to describe everything added in this PR, and I feel at this point that I have done what I felt was reasonable fixes to do right away without pre-optimizing something. It is now ready for review, where each commit may be easier to overview now that there are plenty of changes in a single PR. Each commit is probably quite self-contained.

## In addition to whats listed in #17

- I found the sftp folder outside the helm-chart folder in the end, and updated port to be exposed from 22 -> 2222 aligned with the sshd_config.
- I mounted hubUrl as an environment variable and removed YAML dependencies from the sftp image and stopped mounting anything else.

## Suggested but not part of PR

- Relocate jupyterhub-sftp next to helm-chart/images.
- We create a lint-and-validate-config.yaml to serve the function of lint-and-validate-config.yaml
- We setup a github action someplace to do lint and validation of a Helm chart, and reuse it for z2jh/binderhub/etc, but to start with just something that does `helm template` or so.