### PR TITLE
[WIP] Add Terminado tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install -r dev-requirements.txt
+    - name: Test
+      run: |
+        pytest -v -s ./jupyterhub_ssh/tests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,10 @@
+aiohttp
+asyncssh
 chartpress
+notebook
 pytest
 pyyaml
 pytest-asyncio
-notebook
-aiohttp
+requests
+websockets
 yarl

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,7 @@
 chartpress
 pytest
 pyyaml
+pytest-asyncio
+notebook
+aiohttp
+yarl

--- a/jupyterhub_ssh/tests/test_terminado.py
+++ b/jupyterhub_ssh/tests/test_terminado.py
@@ -1,0 +1,45 @@
+from aiohttp import ClientSession
+import os
+import pytest
+from yarl import URL
+import sys
+
+from notebook.tests.launchnotebook import NotebookTestBase
+
+from ..terminado import Terminado
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+@pytest.fixture
+async def notebook():
+    # Start the notebook
+    notebook = NotebookTestBase()
+    notebook.setup_class()
+    notebook.wait_until_alive()
+    yield notebook
+    notebook.teardown_class()
+
+
+async def test_terminado_client_auth(notebook):
+    # NotebookTestBase uses "/a%40b/" as a hub prefix, we have to make sure we don't escape that
+    notebook_url = URL(notebook.base_url(), encoded=True)
+
+    # Connect to the terminal with a dummy token
+    with pytest.raises(KeyError, match="name"):
+        async with ClientSession() as client, Terminado(notebook_url, "fake", client) as terminado_client:
+            assert terminado_client.terminal_name == "1"
+
+    # Connect to the terminal with the real token
+    async with ClientSession() as client, Terminado(notebook_url, notebook.token, client) as terminado_client:
+        assert terminado_client.terminal_name == "1"
+
+
+async def test_terminado_stdin(notebook):
+    notebook_url = URL(notebook.base_url(), encoded=True)
+
+    # Connect to the terminal with the real token
+    async with ClientSession() as client, Terminado(notebook_url, notebook.token, client) as terminado_client:
+        cmd = f'touch {notebook.home_dir}/hello.txt\n'
+        await terminado_client.send_stdin(cmd)
+        print(os.listdir(notebook.home_dir))


### PR DESCRIPTION
This PR:
* Sets up the testing infra with GHA (hope that's ok)
* **Should** test the terminado client

Some things to consider:
* The `URL` class from `yarl` seems to be escaping the urls if the flag `encoded=True` is not provided.
Because the `NotebookSSHServer` doesn't use this flag, when trying to connect to `http://localhost:12341/a%40b/`, [where the notebook runs](https://github.com/jupyter/notebook/blob/158cc007e82aab767eceec616c9a1e916772a02e/notebook/tests/launchnotebook.py#L41-L45), the url got escaped and got a 404.
* The terminado tests use the [NotebookTestBase](https://github.com/jupyter/notebook/blob/158cc007e82aab767eceec616c9a1e916772a02e/notebook/tests/launchnotebook.py#L34) class

I wanted to open the PR early because I'm a bit stuck with testing writing to stdin (as suggested in https://github.com/yuvipanda/jupyterhub-ssh/issues/13), I don't seem to find the file I'm trying to create anywhere :confused: 

Fixes https://github.com/yuvipanda/jupyterhub-ssh/issues/13
Fixes https://github.com/2i2c-org/external/issues/27