### PR TITLE
Made ssh connection timeout configureable

### DIFF
--- a/helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py
+++ b/helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py
@@ -1,4 +1,7 @@
 from ruamel.yaml import YAML
+from pathlib import Path
+
+sshConnTimeout = Path("/etc/jupyterhub-ssh/config/sshConnTimeout").read_text()
 
 yaml = YAML()
 with open("/etc/jupyterhub-ssh/config/values.yaml") as f:
@@ -7,3 +10,4 @@ with open("/etc/jupyterhub-ssh/config/values.yaml") as f:
 c.JupyterHubSSH.host_key_path = "/etc/jupyterhub-ssh/config/hostKey"
 c.JupyterHubSSH.hub_url = config["hubUrl"]
 c.JupyterHubSSH.debug = True
+c.JupyterHubSSH.ssh_conn_timeout = int(sshConnTimeout)

--- a/helm-chart/jupyterhub-ssh/templates/secret.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/secret.yaml
@@ -10,3 +10,4 @@ stringData:
     {{- .Values | toYaml | nindent 4 }}
   hostKey: {{ .Values.hostKey | required "hostKey must be set to a valid SSH Private key" | quote }}
   hubUrl: {{ .Values.hubUrl | required "hubUrl must be set to a valid JupyterHub URL" | quote }}
+  sshConnTimeout: {{ .Values.ssh.timeout | default 30 | quote }}

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -23,6 +23,9 @@ fullnameOverride: "jupyterhub"
 ssh:
   enabled: true
   replicaCount: 1
+  # Set timeout period for ssh connectoin. May need to set higher if your server
+  # a long time to start. 
+  timeout: 30
 
   image:
     repository: yuvipanda/jupyterhub-ssh-ssh

--- a/jupyterhub_ssh/__init__.py
+++ b/jupyterhub_ssh/__init__.py
@@ -62,8 +62,7 @@ class NotebookSSHServer(asyncssh.SSHServer):
                 # Server start requested, not done yet
                 # We check for a while, reporting progress to user - until we're done
                 try:
-                    # FIXME: Make this configurable?
-                    async with timeout(self.ssh_conn_timeout):
+                    async with timeout(self.app.ssh_conn_timeout):
                         notebook_url = None
                         self._conn.send_auth_banner('Starting your server...')
                         while notebook_url is None:

--- a/jupyterhub_ssh/__init__.py
+++ b/jupyterhub_ssh/__init__.py
@@ -63,7 +63,7 @@ class NotebookSSHServer(asyncssh.SSHServer):
                 # We check for a while, reporting progress to user - until we're done
                 try:
                     # FIXME: Make this configurable?
-                    async with timeout(30):
+                    async with timeout(self.ssh_conn_timeout):
                         notebook_url = None
                         self._conn.send_auth_banner('Starting your server...')
                         while notebook_url is None:
@@ -234,6 +234,16 @@ class JupyterHubSSH(Application):
         Path to host's private SSH Key.
 
         *Must* be set.
+        """,
+        config=True
+    )
+
+    ssh_conn_timeout = Integer(
+        30,
+        help="""
+        Timeout period for ssh connection.
+
+        Set higher if your server takes longer to start.
         """,
         config=True
     )


### PR DESCRIPTION
It's likely not the most elegant way to do this, but it is working. One issue I kept running into is that k8s does not like integers for values. So I had to use a workaround in the config to get it to work. The other option I would be to put jupyterhub_ssh_config.py in a configmap and put that in the deployment.  I almost think that is the better route.