### PR TITLE
Use quay.io for images

### DIFF
--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -1,6 +1,6 @@
 charts:
   - name: jupyterhub-ssh
-    imagePrefix: yuvipanda/jupyterhub-ssh-
+    imagePrefix: quay.io/yuvipanda/jupyterhub-ssh-
     repo:
       git: yuvipanda/jupyterhub-ssh
       published: https://yuvipanda.github.io/jupyterhub-ssh/

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -1,6 +1,6 @@
 charts:
   - name: jupyterhub-ssh
-    imagePrefix: quay.io/yuvipanda/jupyterhub-ssh-
+    imagePrefix: quay.io/jupyterhub-ssh/
     repo:
       git: yuvipanda/jupyterhub-ssh
       published: https://yuvipanda.github.io/jupyterhub-ssh/


### PR DESCRIPTION
DockerHub has been reducing their free plan features,
and don't allow per-repo scopes on their access tokens.
quay.io isn't VC funded and hopefully can be a better
long term home.