### PR TITLE
Misc updates to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JupyterHub SSH and SFTP
 
-[![Documentation build status](https://img.shields.io/readthedocs/jupyterhub?logo=read-the-docs)](https://jupyterhub-ssh.readthedocs.io/en/latest/)
+[![Documentation build status](https://img.shields.io/readthedocs/jupyterhub-ssh?logo=read-the-docs)](https://jupyterhub-ssh.readthedocs.io/en/latest/)
+[![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/zero-to-jupyterhub-k8s/Test%20chart?logo=github&label=tests)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions)
 
 Access through [SSH](https://www.ssh.com/ssh) any JupyterHub, regardless how it was deployed and easily transfer files through [SFTP](https://www.ssh.com/ssh/sftp).
 With a JupyterHub [SSH](https://www.ssh.com/ssh) server deployed, you can start and access your JupyterHub user environment through SSH. With a JupyterHub

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ proxy:
      #
      # We must accept traffic to the k8s Service (proxy-public) receiving traffic
      # from the internet. Port 22 is typically used for both SSH and SFTP, but we
-     # can't use the same port for both so we use 23.
+     # can't use the same port for both so we use 2222 for SFTP in this example.
      #
      extraPorts:
        - name: ssh
          port: 22
          targetPort: ssh
        - name: sftp
-         port: 23
+         port: 2222
          targetPort: sftp
 
    traefik:
@@ -125,7 +125,7 @@ proxy:
        - name: ssh
          containerPort: 8022
        - name: sftp
-         containerPort: 8023
+         containerPort: 2222
      networkPolicy:
        allowedIngressPorts: [http, https, ssh]
 
@@ -140,7 +140,7 @@ proxy:
          ssh-entrypoint:
            address: :8022
          ssh-entrypoint:
-           address: :8023
+           address: :2222
      extraDynamicConfig:
        tcp:
          services:
@@ -154,13 +154,11 @@ proxy:
                  - address: jupyterhub-sftp:22
          routers:
            ssh-router:
-             entrypoints:
-               - ssh-entrypoint
+             entrypoints: [ssh-entrypoint]
              rule: HostSNI(`*`)
              service: ssh-service
            sftp-router:
-             entrypoints:
-               - sftp-entrypoint
+             entrypoints: [sftp-entrypoint]
              rule: HostSNI(`*`)
              service: sftp-service
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The JupyterHub SSH service provides SSH access to your user environment in a Jup
 
 ![Overview](https://raw.githubusercontent.com/yuvipanda/jupyterhub-ssh/main/docs/source/_static/images/technical-overview.png)
 
-Apart from SSH access to JupyterHub, once `jupyterhub-ssh` was deployed, you can also use it to tranfer files from your local
+Apart from SSH access to JupyterHub, once `jupyterhub-ssh` was deployed, you can also use it to transfer files from your local
 home directory into your remote hub home directory. This is achieved through `jupyterhub-sftp`, a service that provides a SFTP
 setup using [OpenSSH](https://www.openssh.com/). `jupyterhub-sftp` currently supports only [NFS](https://tldp.org/LDP/nag/node140.html)
 based home directories.
@@ -30,14 +30,16 @@ based home directories.
 
 Instructions on how to install and deploy JupyterHub SSH & SFTP services.
 
-### Regular deployment
+### Regular deployment (jupyterhub ssh only)
 
 1. Clone the repo and install the jupyterhub-ssh package:
+
    ```bash
    $ git clone https://github.com/yuvipanda/jupyterhub-ssh.git
    $ cd jupyterhub-ssh
    $ pip install -e .
    ```
+
 1. Or install the package directly:
 
    ```bash
@@ -59,35 +61,126 @@ Instructions on how to install and deploy JupyterHub SSH & SFTP services.
 
 1. Start the JupyterHubSSH app from the directory where the config file
    `jupyterhub_ssh_config.py` is located:
-   `bash $ python -m jupyterhub_ssh `
 
-### Kubernetes based deployment
+   ```bash
+   python -m jupyterhub_ssh
+   ```
 
-If your JupyterHub was deployed using Kubernetes, you can use the Helm charts available in this repo to deploy JupyterHub SSH & SFTP
-directly into your Kubernetes cluster.
+### Kubernetes based deployment (jupyterhub ssh and/or sftp)
 
-- Let helm the command line tool know about a Helm chart repository that we decide to name jupyterhub.
-  ```bash
-  $ helm repo add jupyterhub-ssh https://yuvipanda.github.io/jupyterhub-ssh/
-  $ helm repo update
-  ```
-- Simplified example on how to install a Helm chart from a Helm chart repository named jupyterhub-ssh. See the Helm chart's documentation
-  for additional details required.
-  ```bash
-  $ helm install jupyterhub-ssh/jupyterhub-ssh --version <helm chart version> --set hubUrl=https://jupyter.example.org --set-file hostKey=<path to a private SSH key>
-  ```
+If your JupyterHub has been deployed to Kubernetes, you can use the Helm chart
+available in this repo to deploy JupyterHub SSH and/or JupyterHub SFTP directly
+into your Kubernetes cluster.
+
+```bash
+helm install <helm-release-name> \
+   --repo https://yuvipanda.github.io/jupyterhub-ssh/ jupyterhub-ssh \
+   --version <helm chart version> \
+   --set hubUrl=https://jupyter.example.org \
+   --set ssh.enabled=true \
+   --set sftp.enabled=false
+```
+
+If you install JupyterHub SFTP, then it needs access to the home folders. These
+home folders are assumed to be exposed via a k8s PVC resource that you should
+name via the `sftp.pvc.name` configuration.
+
+If your JupyterHub has been deployed using [the official JupyterHub Helm
+chart](https://z2jh.jupyter.org) version 1.1.0 or later, and you have
+_configured the official JupyterHub Helm chart_ with `proxy.https.enabled=true`
+and `proxy.https.type=letsencrypt`, then you can add the following to to acquire
+access to the jupyterhub-ssh and jupyterhub-sftp services via that setup.
+
+```yaml
+# Configuration for the official JupyterHub Helm chart to accept traffic via
+proxy:
+   https:
+      enabled: true
+      type: letsencrypt
+      letsencryptEmail: <my-email-here>
+
+   service:
+     # jupyterhub-ssh/sftp integration part 1/3:
+     #
+     # We must accept traffic to the k8s Service (proxy-public) receiving traffic
+     # from the internet. Port 22 is typically used for both SSH and SFTP, but we
+     # can't use the same port for both so we use 23.
+     #
+     extraPorts:
+       - name: ssh
+         port: 22
+         targetPort: ssh
+       - name: sftp
+         port: 23
+         targetPort: sftp
+
+   traefik:
+     # jupyterhub-ssh/sftp integration part 2/3:
+     #
+     # We must accept traffic arriving to the autohttps pod (traefik) from the
+     # proxy-public service. Expose a port and update the NetworkPolicy
+     # to tolerate incoming (ingress) traffic on the exposed port.
+     #
+     extraPorts:
+       - name: ssh
+         containerPort: 8022
+       - name: sftp
+         containerPort: 8023
+     networkPolicy:
+       allowedIngressPorts: [http, https, ssh]
+
+     # jupyterhub-ssh/sftp integration part 3/3:
+     #
+     # We must let traefik know it should listen for traffic (traefik entrypoint)
+     # and route it (traefik router) onwards to the jupyterhub-ssh k8s Service
+     # (traefik service).
+     #
+     extraStaticConfig:
+       entryPoints:
+         ssh-entrypoint:
+           address: :8022
+         ssh-entrypoint:
+           address: :8023
+     extraDynamicConfig:
+       tcp:
+         services:
+           ssh-service:
+             loadBalancer:
+               servers:
+                 - address: jupyterhub-ssh:22
+           sftp-service:
+             loadBalancer:
+               servers:
+                 - address: jupyterhub-sftp:22
+         routers:
+           ssh-router:
+             entrypoints:
+               - ssh-entrypoint
+             rule: HostSNI(`*`)
+             service: ssh-service
+           sftp-router:
+             entrypoints:
+               - sftp-entrypoint
+             rule: HostSNI(`*`)
+             service: sftp-service
+```
 
 ## How to use it
 
 ### How to SSH
 
 1. Login into your JupyterHub and go to `https://<hub-address>/hub/token`.
+
 2. Copy the token from JupyterHub.
+
 3. SSH into JupyterHub:
+
    ```bash
-   $ ssh <username-you-used>@<hub-address>
+   ssh <hub-username>@<hub-address>
    ```
+
 4. Enter the token received from JupyterHub as a password.
+
 5. TADA :tada: Now you have an interactive terminal! You can do anything you would generally interactively do via ssh: run editors,
    fully interactive programs, use the commandline, etc. Some features like non-interactive command running, tunneling, etc are currently
    unavailable.
@@ -95,11 +188,17 @@ directly into your Kubernetes cluster.
 ### How to SFTP
 
 1. Login into your JupyterHub and go to `https://<hub-address>/hub/token`.
+
 2. Copy the token from JupyterHub.
+
 3. Transfer file into Jupyterhub:
+
    - Using the `sftp` command:
+
      ```bash
-     $ sftp <hub-username>@<hub-address>
+     sftp <hub-username>@<hub-address>
      ```
+
 4. Enter the token received from JupyterHub as a password.
+
 5. TADA :tada: Now you can transfer files to and from your home directory on the hubs.


### PR DESCRIPTION
I made a pass to update the readme so I believe that users actually may succeed setting up jupyterhub-ssh against a z2jh helm chart, which is quite complicated. That set of instructions doesn't cover all situations etc, but it adds something for now at least.

This kind of docs should in the long run start migrating to the sphinx based documentation, but I didn't want to transition this project to use that doc system right now.