### PR TITLE
helm chart: add general config passthrough ssh.config

### DIFF
--- a/helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py
+++ b/helm-chart/images/jupyterhub-ssh/jupyterhub_ssh_config.py
@@ -4,6 +4,9 @@ yaml = YAML()
 with open("/etc/jupyterhub-ssh/config/values.yaml") as f:
     config = yaml.load(f)
 
-c.JupyterHubSSH.host_key_path = "/etc/jupyterhub-ssh/config/hostKey"
+# FIXME: help this config migrate to ssh.config as well
 c.JupyterHubSSH.hub_url = config["hubUrl"]
-c.JupyterHubSSH.debug = True
+
+# load generic configuration
+for app, cfg in config["ssh"]["config"].items():
+    c[app].update(cfg)

--- a/helm-chart/jupyterhub-ssh/schema.yaml
+++ b/helm-chart/jupyterhub-ssh/schema.yaml
@@ -41,6 +41,33 @@ properties:
   ssh:
     type: object
     description: TODO
+    properties:
+      config:
+        type: object
+        description: |
+          The Jupyter ecosystem's Python classes expose configuration through
+          [_traitlets_](https://traitlets.readthedocs.io/en/stable/), and this
+          Helm chart config represented as _static_ YAML values will be directly
+          mapped to updating such traitlet configuration.
+
+          __Example__
+
+          If you inspect documentation for JupyterHubSSH the Python class to
+          describing it can be configured like:
+
+          ```python
+          c.JupyterHubSSH.debug = true
+          ```
+
+          Then in this Helm chart, the equivalent configuration would be like
+          this:
+
+          ```yaml
+          hub:
+            config:
+              JupyterHubSSH:
+                debug: true
+          ```
 
   sftp:
     type: object

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -26,6 +26,11 @@ ssh:
   enabled: true
   replicaCount: 1
 
+  config:
+    JupyterHubSSH:
+      debug: true
+      host_key_path: /etc/jupyterhub-ssh/config/hostKey
+
   image:
     repository: quay.io/jupyterhub-ssh/ssh
     tag: "set-by-chartpress"


### PR DESCRIPTION
In z2jh, the introduction of `hub.config` has been great! This PR does the same, introducing a general location to set static configuration of traitlets, such as `JupyterHubSSH.debug`.

Example:

```yaml
ssh:
  config:
    JupyterHubSSH:
      debug: true
```