### PR TITLE
Added support for named server

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,8 @@ proxy:
 4. Enter the token received from JupyterHub as a password.
 
 5. TADA :tada: Now you can transfer files to and from your home directory on the hubs.
+
+
+# Disclaimer
+I do not own this project. Please look at official project at https://github.com/yuvipanda/jupyterhub-ssh
+I just added a few lines of code to support named servers.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ With a JupyterHub [SSH](https://www.ssh.com/ssh) server deployed, you can start 
 [SFTP](https://www.ssh.com/ssh/sftp) server deployed alongside the JupyterHub's user storage, you can use SFTP to work against your JupyterHub user's home directory.
 These services are authenticated using an access token acquired from your JupyterHub's user interface under `/hub/token`.
 
+## What does this fork have? 
+This project a forked project from yuvipanda/jupyterhub_ssh and I was able to directly contribute to create a fork to support one small feature.
+
+Current jupyterhub-ssh by yuvipanda only supports ssh connection to unnamed server. I added few lines to support named server as well. 
+
+The way it'd work is if you have a named server, you'd simply do `ssh user-namedserver@hub_url`
+ 
+It does create the named server automactically if it doesn't exist, which you'll be able to view in the JupyterHub UI as well. 
+
+All the other features remain the same and you can still connect to unnamed server by just `user@hub_url`
+
 ## Development Status
 
 This project is under active develpoment :tada:, so expect a few changes along the way.

--- a/jupyterhub_ssh/__init__.py
+++ b/jupyterhub_ssh/__init__.py
@@ -40,6 +40,9 @@ class NotebookSSHServer(asyncssh.SSHServer):
 
         Else return None
         """
+        # Checking if username has any dash char "-" which would be then have the name of the named server the user wants to connect to
+        # For example username would look like admin-mytestserver. Any characters can be used here but chose - just for the sake of it
+        # If the server name itself has "-" then we would need to split only once. Splitting with split(char, #Occurrence)
         dash_char = "-"
         server_name = ""
         if dash_char in username:
@@ -50,16 +53,6 @@ class NotebookSSHServer(asyncssh.SSHServer):
             if resp.status != 200:
                 return None
             user = await resp.json()
-            # # Checking if username has any - which would be the name of the particular server the user wants to connect to
-            # # For example username would look like admin-mytestserver. Any characters can be used here but chose - just for the sake of it
-            # # If the server name itself has - then we would need to split only once. Splitting with split(char, #Occurrence)
-            # if server_name:
-            #     server = user.get("servers/" + server_name, {}).get("", {})
-            #     if server.get("ready", False):
-            #         return self.app.hub_url / user["servers"][""]["url"][1:]
-            #     else:
-            #         return None
-            # URLs will have preceding slash, but yarl forbids those
             server = user.get("servers", {}).get("", {})
             if server.get("ready", False):
                 return self.app.hub_url / user["servers"][server_name if server_name!="" else ""]["url"][1:]
@@ -70,7 +63,10 @@ class NotebookSSHServer(asyncssh.SSHServer):
         """ """
         # REST API reference:       https://jupyterhub.readthedocs.io/en/stable/_static/rest-api/index.html#operation--users--name--server-post
         # REST API implementation:  https://github.com/jupyterhub/jupyterhub/blob/187fe911edce06eb067f736eaf4cc9ea52e69e08/jupyterhub/apihandlers/users.py#L451-L497
-        dash_char = "-"
+        
+        # Checking if username has any dash char "-" which would be then have the name of the named server the user wants to connect to
+        # For example username would look like admin-mytestserver. Any characters can be used here but chose - just for the sake of it
+        # If the server name itself has "-" then we would need to split only once. Splitting with split(char, #Occurrence)dash_char = "-"
         server_name = ""
         if dash_char in username:
             username_with_server = username.split(dash_char, 1)

--- a/jupyterhub_ssh/__init__.py
+++ b/jupyterhub_ssh/__init__.py
@@ -40,12 +40,12 @@ class NotebookSSHServer(asyncssh.SSHServer):
 
         Else return None
         """
-        dashChar = "-"
-        serverName = ""
-        if dashChar in username:
-            usernameWithServer = username.split(dashChar, 1)
-            username = usernameWithServer[0]
-            serverName = usernameWithServer[1]
+        dash_char = "-"
+        server_name = ""
+        if dash_char in username:
+            username_with_server = username.split(dash_char, 1)
+            username = username_with_server[0]
+            server_name = username_with_server[1]
         async with session.get(self.app.hub_url / "hub/api/users" / username) as resp:
             if resp.status != 200:
                 return None
@@ -53,8 +53,8 @@ class NotebookSSHServer(asyncssh.SSHServer):
             # # Checking if username has any - which would be the name of the particular server the user wants to connect to
             # # For example username would look like admin-mytestserver. Any characters can be used here but chose - just for the sake of it
             # # If the server name itself has - then we would need to split only once. Splitting with split(char, #Occurrence)
-            # if serverName:
-            #     server = user.get("servers/" + serverName, {}).get("", {})
+            # if server_name:
+            #     server = user.get("servers/" + server_name, {}).get("", {})
             #     if server.get("ready", False):
             #         return self.app.hub_url / user["servers"][""]["url"][1:]
             #     else:
@@ -62,7 +62,7 @@ class NotebookSSHServer(asyncssh.SSHServer):
             # URLs will have preceding slash, but yarl forbids those
             server = user.get("servers", {}).get("", {})
             if server.get("ready", False):
-                return self.app.hub_url / user["servers"][serverName if serverName!="" else ""]["url"][1:]
+                return self.app.hub_url / user["servers"][server_name if server_name!="" else ""]["url"][1:]
             else:
                 return None
 
@@ -70,15 +70,15 @@ class NotebookSSHServer(asyncssh.SSHServer):
         """ """
         # REST API reference:       https://jupyterhub.readthedocs.io/en/stable/_static/rest-api/index.html#operation--users--name--server-post
         # REST API implementation:  https://github.com/jupyterhub/jupyterhub/blob/187fe911edce06eb067f736eaf4cc9ea52e69e08/jupyterhub/apihandlers/users.py#L451-L497
-        dashChar = "-"
-        serverName = ""
-        if dashChar in username:
-            usernameWithServer = username.split(dashChar, 1)
-            username = usernameWithServer[0]
-            serverName = usernameWithServer[1]
+        dash_char = "-"
+        server_name = ""
+        if dash_char in username:
+            username_with_server = username.split(dash_char, 1)
+            username = username_with_server[0]
+            server_name = username_with_server[1]
         
-        if serverName:
-            create_url = self.app.hub_url / "hub/api/users" / username / "servers" / serverName
+        if server_name:
+            create_url = self.app.hub_url / "hub/api/users" / username / "servers" / server_name
         else:
             create_url = self.app.hub_url / "hub/api/users" / username / "server"
 
@@ -92,8 +92,8 @@ class NotebookSSHServer(asyncssh.SSHServer):
                 # We manually generate this, even though it's *bad*
                 # Mostly because when the server is already running, JupyterHub
                 # doesn't respond with the whole model!
-                if serverName:
-                    return self.app.hub_url / "user" / username / serverName
+                if server_name:
+                    return self.app.hub_url / "user" / username / server_name
                 return self.app.hub_url / "user" / username
             elif resp.status == 202:
                 # Server start has been requested, now and potentially earlier,
@@ -107,9 +107,9 @@ class NotebookSSHServer(asyncssh.SSHServer):
                         while notebook_url is None:
                             # FIXME: Exponential backoff + make this configurable
                             await asyncio.sleep(0.5)
-                            if serverName:
+                            if server_name:
                                 notebook_url = await self.get_user_server_url(
-                                    session, username + "/" + serverName
+                                    session, username + "/" + server_name
                                 )
                             notebook_url = await self.get_user_server_url(
                                 session, username


### PR DESCRIPTION
## What does this PR have? 

Current jupyterhub-ssh only supports ssh connection to unnamed server. I added few lines to support named server as well. 

The way it'd work is if you have a named server, you'd simply do `ssh user-namedserver@hub_url`

It also does create the named server automactically if it doesn't exist, which you'll be able to view in the JupyterHub UI as well. 

All the other features remain the same and you can still connect to unnamed server by just `user@hub_url`