### PR TITLE
Implement support for init containers and extra volumes/mounts for ssh

### DIFF
--- a/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
+++ b/helm-chart/jupyterhub-ssh/templates/ssh/deployment.yaml
@@ -29,6 +29,14 @@ spec:
         - name: config
           secret:
             secretName: {{ include "jupyterhub-ssh.fullname" . }}
+      {{- with .Values.ssh.extraVolumes }}
+      {{- . | toYaml | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.ssh.initContainers }}
+      initContainers:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           image: "{{ .Values.ssh.image.repository }}:{{ .Values.ssh.image.tag | default .Chart.AppVersion }}"
@@ -40,6 +48,9 @@ spec:
             - name: config
               mountPath: /etc/jupyterhub-ssh/config
               readOnly: true
+          {{- with .Values.ssh.extraVolumeMounts }}
+          {{- . | toYaml | nindent 12 }}
+          {{- end }}
           ports:
             - name: ssh
               containerPort: 8022

--- a/helm-chart/jupyterhub-ssh/values.yaml
+++ b/helm-chart/jupyterhub-ssh/values.yaml
@@ -54,6 +54,10 @@ ssh:
   affinity: {}
   networkPolicy: {}
 
+  initContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
 sftp:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
While the service itself does not require them, there are situations that may.

The example at hand is connecting to a JupyterHub instance that uses a custom certificate authority.

To the best of my knowledge there are two solutions:

- Create a custom image that contains all the required certificates
- Use an init container that will update the system's certs storage with additional certificates

This patch implements the latter as it avoids creating new images just for that purpose and the additional certificates can be easily changed using a central storage.